### PR TITLE
Add Maven compiler plugin to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,15 @@
                 <artifactId>allure-maven</artifactId>
                 <version>2.12.0</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>19</source>
+                    <target>19</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The Maven compiler plugin has been added to the pom.xml file. This plugin is set to version 3.8.1 and the configuration was set with a source and target value of 19.