### PR TITLE
Update Allure results directory location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
                     <systemProperties>
                         <property>
                             <name>allure.results.directory</name>
-                            <value>${project.build.directory}/allure-results</value>
+                            <value>${project.build.directory}/target/allure-results</value>
                         </property>
                     </systemProperties>
                 </configuration>


### PR DESCRIPTION
The Allure results directory location in the project's pom.xml file has been modified. Instead of directing to `${project.build.directory}/allure-results`, it now directs to `${project.build.directory}/target/allure-results`. This change ensures the Allure results now reside within the project's target directory.