### PR TITLE
Set headless mode to true in playwright tests

### DIFF
--- a/src/main/java/com/example/saveatrainplaywrith/PlaywrightTestBase.java
+++ b/src/main/java/com/example/saveatrainplaywrith/PlaywrightTestBase.java
@@ -50,7 +50,7 @@ public class PlaywrightTestBase {
     @BeforeAll
     static void initBrowser() {
         playwright = Playwright.create();
-        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(false).setSlowMo(1000));
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true).setSlowMo(1000));
     }
 
     @AfterAll


### PR DESCRIPTION
The headless mode for the playwright-based browser tests was changed from false to true. This action will make the tests run without a UI, which can speed up testing and make it more suitable for automated testing environments.