### PR TITLE
Move LoadTimeTest to resources folder

### DIFF
--- a/src/main/resources/load/LoadTimeTest.java
+++ b/src/main/resources/load/LoadTimeTest.java
@@ -1,4 +1,4 @@
-package com.example.load;
+package load;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;


### PR DESCRIPTION
Relocated the LoadTimeTest from the test/java directory to main/resources/load. This change also involved updating the package declaration to match its new location.