### PR TITLE
Add parameterized tests using excel data

### DIFF
--- a/src/main/java/com/example/saveatrainplaywrith/PlaywrightTestBase.java
+++ b/src/main/java/com/example/saveatrainplaywrith/PlaywrightTestBase.java
@@ -50,7 +50,7 @@ public class PlaywrightTestBase {
     @BeforeAll
     static void initBrowser() {
         playwright = Playwright.create();
-        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(false).setSlowMo(1000));
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true).setSlowMo(1000));
     }
 
     @AfterAll

--- a/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForACP_Tests.java
+++ b/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForACP_Tests.java
@@ -1,4 +1,35 @@
 package com.example.saveatrainplaywrith;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import utils.ExcelReader;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
 public class SaveATrain_MixE2E_ForACP_Tests {
+    @ParameterizedTest
+    @MethodSource("excelDataProvider")
+    void testUsingExcelData(String originUID, String destinationUID, String departureDatetime) {
+        System.out.println(originUID);
+        System.out.println(destinationUID);
+        System.out.println(departureDatetime);
+        // originUID, destinationUID, and departureDatetime corresponds to the columns in Excel sheet
+    }
+
+    static Stream<Arguments> excelDataProvider() throws IOException {
+        String filePath = "/Users/rafalst/IdeaProjects/SaveATrainPlaywrith/src/test/resources/ConnectionsACP.xlsx";
+        return ExcelReader.readExcelData(filePath)
+                .filter(arg -> isValidRow(arg.get()));
+    }
+
+    private static boolean isValidRow(Object[] records) {
+        if (records.length != 3) return false;
+        for (Object record : records) {
+            String str = (String) record;
+            if (str == null || str.equals("BLANK") || str.equals("UNKNOWN")) return false;
+        }
+        return true;
+    }
 }

--- a/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForEurail_Tests.java
+++ b/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForEurail_Tests.java
@@ -1,4 +1,35 @@
 package com.example.saveatrainplaywrith;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import utils.ExcelReader;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
 public class SaveATrain_MixE2E_ForEurail_Tests {
+    @ParameterizedTest
+    @MethodSource("excelDataProvider")
+    void testUsingExcelData(String originUID, String destinationUID, String departureDatetime) {
+        System.out.println(originUID);
+        System.out.println(destinationUID);
+        System.out.println(departureDatetime);
+        // originUID, destinationUID, and departureDatetime corresponds to the columns in Excel sheet
+    }
+
+    static Stream<Arguments> excelDataProvider() throws IOException {
+        String filePath = "/Users/rafalst/IdeaProjects/SaveATrainPlaywrith/src/test/resources/ConnectionsEurail.xlsx";
+        return ExcelReader.readExcelData(filePath)
+                .filter(arg -> isValidRow(arg.get()));
+    }
+
+    private static boolean isValidRow(Object[] records) {
+        if (records.length != 3) return false;
+        for (Object record : records) {
+            String str = (String) record;
+            if (str == null || str.equals("BLANK") || str.equals("UNKNOWN")) return false;
+        }
+        return true;
+    }
 }

--- a/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForNSI_Tests.java
+++ b/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForNSI_Tests.java
@@ -1,4 +1,35 @@
 package com.example.saveatrainplaywrith;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import utils.ExcelReader;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
 public class SaveATrain_MixE2E_ForNSI_Tests {
+    @ParameterizedTest
+    @MethodSource("excelDataProvider")
+    void testUsingExcelData(String originUID, String destinationUID, String departureDatetime) {
+        System.out.println(originUID);
+        System.out.println(destinationUID);
+        System.out.println(departureDatetime);
+        // originUID, destinationUID, and departureDatetime corresponds to the columns in Excel sheet
+    }
+
+    static Stream<Arguments> excelDataProvider() throws IOException {
+        String filePath = "/Users/rafalst/IdeaProjects/SaveATrainPlaywrith/src/test/resources/ConnectionsNSI.xlsx";
+        return ExcelReader.readExcelData(filePath)
+                .filter(arg -> isValidRow(arg.get()));
+    }
+
+    private static boolean isValidRow(Object[] records) {
+        if (records.length != 3) return false;
+        for (Object record : records) {
+            String str = (String) record;
+            if (str == null || str.equals("BLANK") || str.equals("UNKNOWN")) return false;
+        }
+        return true;
+    }
 }

--- a/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForTrainItalia_Tests.java
+++ b/src/test/java/com/example/saveatrainplaywrith/SaveATrain_MixE2E_ForTrainItalia_Tests.java
@@ -1,5 +1,35 @@
 package com.example.saveatrainplaywrith;
 
-public class SaveATrain_MixE2E_ForTrainItalia_Tests {
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import utils.ExcelReader;
 
+import java.io.IOException;
+import java.util.stream.Stream;
+
+public class SaveATrain_MixE2E_ForTrainItalia_Tests {
+    @ParameterizedTest
+    @MethodSource("excelDataProvider")
+    void testUsingExcelData(String originUID, String destinationUID, String departureDatetime) {
+        System.out.println(originUID);
+        System.out.println(destinationUID);
+        System.out.println(departureDatetime);
+        // originUID, destinationUID, and departureDatetime corresponds to the columns in Excel sheet
+    }
+
+    static Stream<Arguments> excelDataProvider() throws IOException {
+        String filePath = "/Users/rafalst/IdeaProjects/SaveATrainPlaywrith/src/test/resources/ConnectionsTrainItalia.xlsx";
+        return ExcelReader.readExcelData(filePath)
+                .filter(arg -> isValidRow(arg.get()));
+    }
+
+    private static boolean isValidRow(Object[] records) {
+        if (records.length != 3) return false;
+        for (Object record : records) {
+            String str = (String) record;
+            if (str == null || str.equals("BLANK") || str.equals("UNKNOWN")) return false;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
Added parameterized tests for TrainItalia, NSI, Eurail, and ACP in their respective test classes. Each test now reads data from an Excel file, filters out invalid rows and uses the data for the test. Also, updated PlaywrightTestBase to run headless browser tests.